### PR TITLE
Fix comdirect parsing

### DIFF
--- a/.changes/unreleased/Fixed-20250405-075757.yaml
+++ b/.changes/unreleased/Fixed-20250405-075757.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix comdirect issue by switching to a more robust parsing where the header is not expected at a fixed position
+time: 2025-04-05T07:57:57.891290406Z

--- a/pkg/parser/comdirect_test.go
+++ b/pkg/parser/comdirect_test.go
@@ -66,8 +66,8 @@ func TestComdirectParseFileNokInvalidHeader(t *testing.T) {
 		if pError.ErrorType != HeaderError {
 			t.Errorf("HeaderError expected, got '%s' instead", pError.ErrorType)
 		}
-		if pError.Line != 5 {
-			t.Errorf("Expected error on line 5, got %d", pError.Line)
+		if pError.Line != 0 {
+			t.Errorf("Expected error on line 0, got %d", pError.Line)
 		}
 	} else {
 		t.Error("ParserError expected")
@@ -89,8 +89,8 @@ func TestComdirectParseFileNokWrongBuchungstag(t *testing.T) {
 		if pError.ErrorType != DataParsingError {
 			t.Errorf("DataParsingError expected, got '%s' instead", pError.ErrorType)
 		}
-		if pError.Line != 6 {
-			t.Errorf("Expected error on line 6, got %d", pError.Line)
+		if pError.Line != 3 {
+			t.Errorf("Expected error on line 3, got %d", pError.Line)
 		}
 		if pError.Field != "Buchungstag" {
 			t.Errorf("Expected error on field 'Buchungstag', got %s", pError.Field)
@@ -115,8 +115,8 @@ func TestComdirectParseFileNokWrongUmsatz(t *testing.T) {
 		if pError.ErrorType != DataParsingError {
 			t.Errorf("DataParsingError expected, got '%s' instead", pError.ErrorType)
 		}
-		if pError.Line != 6 {
-			t.Errorf("Expected error on line 6, got %d", pError.Line)
+		if pError.Line != 3 {
+			t.Errorf("Expected error on line 3, got %d", pError.Line)
 		}
 		if pError.Field != "Umsatz in EUR" {
 			t.Errorf("Expected error on field 'Umsatz in EUR', got %s", pError.Field)

--- a/pkg/parser/dkb_test.go
+++ b/pkg/parser/dkb_test.go
@@ -65,8 +65,8 @@ func TestDkbParseFileNokInvalidHeader(t *testing.T) {
 		if pError.ErrorType != HeaderError {
 			t.Errorf("HeaderError expected, got '%s' instead", pError.ErrorType)
 		}
-		if pError.Line != 5 {
-			t.Errorf("Expected error on line 5, got %d", pError.Line)
+		if pError.Line != 0 {
+			t.Errorf("Expected error on line 0, got %d", pError.Line)
 		}
 	} else {
 		t.Error("ParserError expected")
@@ -88,8 +88,8 @@ func TestDkbParseFileNokWrongBuchungsdatum(t *testing.T) {
 		if pError.ErrorType != DataParsingError {
 			t.Errorf("DataParsingError expected, got '%s' instead", pError.ErrorType)
 		}
-		if pError.Line != 6 {
-			t.Errorf("Expected error on line 6, got %d", pError.Line)
+		if pError.Line != 5 {
+			t.Errorf("Expected error on line 5, got %d", pError.Line)
 		}
 		if pError.Field != "Buchungsdatum" {
 			t.Errorf("Expected error on field 'Buchungsdatum', got '%s'", pError.Field)
@@ -114,8 +114,8 @@ func TestDkbParseFileNokWrongWertstellung(t *testing.T) {
 		if pError.ErrorType != DataParsingError {
 			t.Errorf("DataParsingError expected, got '%s' instead", pError.ErrorType)
 		}
-		if pError.Line != 6 {
-			t.Errorf("Expected error on line 6, got %d", pError.Line)
+		if pError.Line != 5 {
+			t.Errorf("Expected error on line 5, got %d", pError.Line)
 		}
 		if pError.Field != "Wertstellung" {
 			t.Errorf("Expected error on field 'Wertstellung', got '%s'", pError.Field)
@@ -140,8 +140,8 @@ func TestDkbParseFileNokWrongBetrag(t *testing.T) {
 		if pError.ErrorType != DataParsingError {
 			t.Errorf("DataParsingError expected, got '%s' instead", pError.ErrorType)
 		}
-		if pError.Line != 6 {
-			t.Errorf("Expected error on line 6, got %d", pError.Line)
+		if pError.Line != 5 {
+			t.Errorf("Expected error on line 5, got %d", pError.Line)
 		}
 		if pError.Field != "Betrag (€)" {
 			t.Errorf("Expected error on field 'Betrag (€)', got '%s'", pError.Field)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -110,7 +110,8 @@ type ParserError struct {
 	ErrorType ParserErrorType
 
 	// Optional line number where the error occurs. Line numbers are
-	// 1 based. The value "0" means no line number applies here.
+	// 1 based. The value "0" means no line number applies here, e.g.
+	// when no header has been found. Empty lines are not counted.
 	Line int
 
 	// Optional field name where the error occured


### PR DESCRIPTION
Introduce a more robust parsing, use it also for DKB.

Errors now have the CSVReader line number which means that empty lines are ommited in counting.