### PR TITLE
List the supported formats in a stable order

### DIFF
--- a/.changes/unreleased/Fixed-20260725-154144.yaml
+++ b/.changes/unreleased/Fixed-20260725-154144.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: List the supported formats in a stable order
+time: 2026-07-25T15:41:44.604177418Z

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -6,6 +6,7 @@ package parser
 import (
 	"fmt"
 	"os"
+	"slices"
 )
 
 // SourceFormat is the source file format
@@ -48,11 +49,18 @@ func GetParser(s SourceFormat) Parser {
 }
 
 // GetSourceFormats returns the list of supported source formats.
+//
+// The formats are returned in the order in which they are defined. Sorting is
+// needed as the iteration order of a map is not specified: without it the
+// result differs between calls, which shows up in the output of the
+// "list-formats" command and in the order in which GetGuessedParser tries the
+// parsers.
 func GetSourceFormats() []SourceFormat {
 	formats := make([]SourceFormat, 0, len(sourceFormats))
 	for key := range sourceFormats {
 		formats = append(formats, key)
 	}
+	slices.Sort(formats)
 	return formats
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2,8 +2,29 @@ package parser
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 )
+
+// The order of the returned formats has to be stable: it determines the output
+// of the "list-formats" command and the order in which GetGuessedParser tries
+// the parsers.
+func TestGetSourceFormatsOrder(t *testing.T) {
+	expected := []SourceFormat{MoneyWallet, Barclaycard, Volksbank, Comdirect, DKB}
+
+	formats := GetSourceFormats()
+	if !slices.Equal(formats, expected) {
+		t.Errorf("Expected %v, got %v", expected, formats)
+	}
+
+	// Repeated calls keep the order. Without sorting this fails, as the
+	// iteration order of a map is randomized.
+	for i := 0; i < 100; i++ {
+		if !slices.Equal(GetSourceFormats(), expected) {
+			t.Fatalf("Call %d returned a different order: %v", i, GetSourceFormats())
+		}
+	}
+}
 
 func TestGetParser(t *testing.T) {
 	for _, f := range GetSourceFormats() {


### PR DESCRIPTION
## Problem

`GetSourceFormats` built its result by iterating over the `sourceFormats` map. The iteration order of a map is not specified, so the returned order differed between calls:

```
$ for i in 1 2 3 4; do go-homebank-csv list-formats | tr '\n' ' '; echo; done
MoneyWallet Barclaycard Volksbank Comdirect DKB
Volksbank Comdirect DKB MoneyWallet Barclaycard
Barclaycard Volksbank Comdirect DKB MoneyWallet
DKB MoneyWallet Barclaycard Volksbank Comdirect
```

This is visible in two places:

* The output of `list-formats` changes on every invocation.
* `GetGuessedParser` iterates over `GetSourceFormats()` and therefore tried the parsers in a random order. Autodetection was not reproducible for a file that is accepted by more than one parser. The currently supported formats have distinctive headers, so this did not produce wrong results in practice, but the behaviour was not deterministic.

## Fix

Sort the result. Sorting by the underlying value yields the order of the `const` block, which also matches the list of supported formats in `README.md`:

```
MoneyWallet Barclaycard Volksbank Comdirect DKB
```

`README.md` needed no update, it already documents the formats in this order.

## Tests

`TestGetSourceFormatsOrder` asserts the exact expected order and then calls `GetSourceFormats` 100 more times to check that the order does not change. Without the sort the test fails on the first mismatching call, for example:

```
parser_test.go:24: Call 0 returned a different order: [Volksbank Comdirect DKB MoneyWallet Barclaycard]
```

Verified by reverting `parser.go` and observing the failure, so this is a real regression test.

## Verification

`make all` passes: `golangci-lint` reports 0 issues, all tests pass, build succeeds. Running the built binary repeatedly now prints the same order every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzrJKmThM4AmehDwPyxBp6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzrJKmThM4AmehDwPyxBp6)_