### PR TITLE
Report the correct line number for MoneyWallet parsing errors

### DIFF
--- a/.changes/unreleased/Fixed-20260725-154805.yaml
+++ b/.changes/unreleased/Fixed-20260725-154805.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Report the correct line number for MoneyWallet parsing errors
+time: 2026-07-25T15:48:05.120576418Z

--- a/pkg/parser/moneywallet.go
+++ b/pkg/parser/moneywallet.go
@@ -54,7 +54,7 @@ func (m *moneywalletParser) ParseFile(filepath string) error {
 		if err != nil {
 			return &ParserError{
 				ErrorType: DataParsingError,
-				Line:      lineNr + 1,
+				Line:      lineNr + 2,
 				Field:     "datetime",
 			}
 		}
@@ -65,7 +65,7 @@ func (m *moneywalletParser) ParseFile(filepath string) error {
 		if err != nil {
 			return &ParserError{
 				ErrorType: DataParsingError,
-				Line:      lineNr + 1,
+				Line:      lineNr + 2,
 				Field:     "money",
 			}
 		}

--- a/pkg/parser/moneywallet_test.go
+++ b/pkg/parser/moneywallet_test.go
@@ -95,8 +95,9 @@ func TestMoneywalletParseFileNokWrongDatetime(t *testing.T) {
 		if pError.ErrorType != DataParsingError {
 			t.Error("Expected DataParsingError")
 		}
-		if pError.Line != 1 {
-			t.Errorf("Expected DataParsingError on line 1, got %d", pError.Line)
+		// The header is line 1, so the first data row is line 2
+		if pError.Line != 2 {
+			t.Errorf("Expected DataParsingError on line 2, got %d", pError.Line)
 		}
 		if pError.Field != "datetime" {
 			t.Errorf("Expected field 'datetime', got '%s' instead", pError.Field)
@@ -107,6 +108,31 @@ func TestMoneywalletParseFileNokWrongDatetime(t *testing.T) {
 
 	if len(mw.entries) != 0 {
 		t.Error("Entries should be empty")
+	}
+}
+
+// The reported line number has to follow the data rows, not only match the
+// first one
+func TestMoneywalletParseFileNokWrongDatetimeSecondRow(t *testing.T) {
+	fpath := filepath.Join("testfiles", "moneywallet", "MoneyWallet_nok_wrongdatetime_secondrow.csv")
+	mw := &moneywalletParser{}
+	err := mw.ParseFile(fpath)
+	if err == nil {
+		t.Error("Should fail")
+	}
+	var pError *ParserError
+	if errors.As(err, &pError) {
+		if pError.ErrorType != DataParsingError {
+			t.Error("Expected DataParsingError")
+		}
+		if pError.Line != 3 {
+			t.Errorf("Expected DataParsingError on line 3, got %d", pError.Line)
+		}
+		if pError.Field != "datetime" {
+			t.Errorf("Expected field 'datetime', got '%s' instead", pError.Field)
+		}
+	} else {
+		t.Error("Expected ParserError")
 	}
 }
 
@@ -122,8 +148,9 @@ func TestMoneywalletParseFileNokWrongMoney(t *testing.T) {
 		if pError.ErrorType != DataParsingError {
 			t.Error("Expected DataParsingError")
 		}
-		if pError.Line != 1 {
-			t.Errorf("Expected DataParsingError on line 1, got %d", pError.Line)
+		// The header is line 1, so the first data row is line 2
+		if pError.Line != 2 {
+			t.Errorf("Expected DataParsingError on line 2, got %d", pError.Line)
 		}
 		if pError.Field != "money" {
 			t.Errorf("Expected field 'money', got '%s' instead", pError.Field)

--- a/pkg/parser/testfiles/moneywallet/MoneyWallet_nok_wrongdatetime_secondrow.csv
+++ b/pkg/parser/testfiles/moneywallet/MoneyWallet_nok_wrongdatetime_secondrow.csv
@@ -1,0 +1,3 @@
+"wallet","currency","category","datetime","money","description"
+"Bargeld","EUR","Einkäufe","2020-12-28 12:17:09","-8,40","einkäufe"
+"Bargeld","EUR","Einkäufe","28.12.2020 12:17:09","-8,40","einkäufe"


### PR DESCRIPTION
## Problem

The data loop of the MoneyWallet parser iterates over `records[1:]`, so `lineNr` 0 refers to the first data row, which is line 2 of the file. Both `ParserError` values used `lineNr + 1` and therefore reported every error one line too early. A broken first data row was blamed on the header line:

```
MoneyWallet, broken value on file line 2 -> DataParsingError in line 1 in field name 'datetime'
Volksbank,   broken value on file line 2 -> DataParsingError in line 2 in field name 'Buchungstag'
```

## Fix

Add 2 instead of 1, which is what the `volksbank` parser already does for the identical loop structure.

MoneyWallet was the only affected format. Checked all parsers:

| Parser | Loop | Offset | Correct |
| --- | --- | --- | --- |
| `moneywallet` | `records[1:]` | was `lineNr + 1` | no, fixed to `lineNr + 2` |
| `volksbank` | `records[1:]` | `lineNr + 2` | yes |
| `comdirect` | `records[headerIndex+1:]` | `lineNr + headerIndex + 2` | yes |
| `dkb` | `records[headerIndex+1:]` | `headerIndex + lineNr + 2` | yes |
| `barclaycard` | all `rows` | `lineNr + 1` | yes, the index is absolute |

## Tests

The expectations of the two existing tests encoded the wrong value and are corrected to line 2.

Both existing fixtures have their broken value in the first data row, where an off-by-one is only visible as the difference between line 1 and line 2. The new fixture `MoneyWallet_nok_wrongdatetime_secondrow.csv` puts the broken value in the second data row, so the test also verifies that the reported line follows the data rows instead of only matching the first one.

All three line assertions fail without this change, reporting lines 1, 2 and 1 instead of 2, 3 and 2. Verified by reverting `moneywallet.go`.

The new test intentionally does not assert on `entries`. Unlike the existing cases, the failing row is not the first one, so the parser has already collected the preceding valid record when it aborts. That partial state is incidental to the reported line number, which is what this test is about.

## Verification

`make all` passes: `golangci-lint` reports 0 issues, all tests pass, build succeeds. Fixture data is synthetic and follows the existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzrJKmThM4AmehDwPyxBp6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzrJKmThM4AmehDwPyxBp6)_