### PR TITLE
Fix broken CSV output when a text field contains a semicolon or a line break

### DIFF
--- a/.changes/unreleased/Fixed-20260725-204938.yaml
+++ b/.changes/unreleased/Fixed-20260725-204938.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix broken CSV output when a text field contains a semicolon or a line break
+time: 2026-07-25T20:49:38.230785574Z

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 )
 
 // SourceFormat is the source file format
@@ -181,6 +182,27 @@ type homebankRecord struct {
 	tags     string
 }
 
+// homebankFieldSeparator separates the fields of a homebank CSV file
+const homebankFieldSeparator = ";"
+
+// sanitizeHomebankField makes the content of a text field safe to write.
+//
+// The fields are separated by homebankFieldSeparator. A separator inside a
+// field would shift all following fields of the record, a line break would end
+// the record early. Both are replaced instead of quoted: the format does not
+// document a way to quote or escape a field, so a quoted separator cannot be
+// relied on to be understood by the importing side.
+//
+// Bank data does contain such characters, e.g. a "Verwendungszweck" with a
+// semicolon, so dropping the affected records is not an option.
+func sanitizeHomebankField(value string) string {
+	value = strings.ReplaceAll(value, homebankFieldSeparator, ",")
+	value = strings.ReplaceAll(value, "\r\n", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	return value
+}
+
 // writeHomeBankRecords writes a slice of HomebankRecord to a CSV file
 // See "Transaction import CSV format" under http://homebank.free.fr/help/misc-csvformat.html
 func writeHomeBankRecords(records []homebankRecord, filepath string) error {
@@ -197,8 +219,16 @@ func writeHomeBankRecords(records []homebankRecord, filepath string) error {
 	}
 
 	for _, rec := range records {
+		// date is a formatted timestamp, payment and amount are numbers, so
+		// only the text fields can contain a separator or a line break
 		line := fmt.Sprintf("%s;%d;%s;%s;%s;%f;%s;%s",
-			rec.date, rec.payment, rec.info, rec.payee, rec.memo, rec.amount, rec.category, rec.tags)
+			rec.date, rec.payment,
+			sanitizeHomebankField(rec.info),
+			sanitizeHomebankField(rec.payee),
+			sanitizeHomebankField(rec.memo),
+			rec.amount,
+			sanitizeHomebankField(rec.category),
+			sanitizeHomebankField(rec.tags))
 		_, err := fmt.Fprintln(outfile, line)
 		if err != nil {
 			return err

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,10 +1,76 @@
 package parser
 
 import (
+	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
+
+func TestSanitizeHomebankField(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"a plain memo", "a plain memo"},
+		{"", ""},
+		{"Rechnung; Nr 123", "Rechnung, Nr 123"},
+		{"a;b;c", "a,b,c"},
+		{"line1\r\nline2", "line1 line2"},
+		{"line1\nline2", "line1 line2"},
+		{"line1\rline2", "line1 line2"},
+		{"mixed;value\nwith both", "mixed,value with both"},
+	}
+
+	for _, c := range cases {
+		got := sanitizeHomebankField(c.input)
+		if got != c.expected {
+			t.Errorf("Input %q: expected %q, got %q", c.input, c.expected, got)
+		}
+	}
+}
+
+// A separator or a line break inside a text field must not shift the fields of
+// the written record
+func TestWriteHomeBankRecordsSanitizesFields(t *testing.T) {
+	records := []homebankRecord{
+		{
+			date:     "2024-01-01",
+			payment:  0,
+			info:     "info;with;separator",
+			payee:    "Payee; Name",
+			memo:     "memo;with\nline break",
+			amount:   -1.5,
+			category: "cat;egory",
+			tags:     "tag;one",
+		},
+	}
+
+	fpath := filepath.Join(t.TempDir(), "output.csv")
+	if err := writeHomeBankRecords(records, fpath); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(fpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(strings.TrimRight(string(content), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("Expected a header and one record, got %d lines: %q", len(lines), lines)
+	}
+	for i, line := range lines {
+		if fields := strings.Count(line, homebankFieldSeparator) + 1; fields != 8 {
+			t.Errorf("Line %d has %d fields instead of 8: %s", i+1, fields, line)
+		}
+	}
+
+	expected := "2024-01-01;0;info,with,separator;Payee, Name;memo,with line break;-1.500000;cat,egory;tag,one"
+	if lines[1] != expected {
+		t.Errorf("Expected:\n%s\ngot:\n%s", expected, lines[1])
+	}
+}
 
 // The order of the returned formats has to be stable: it determines the output
 // of the "list-formats" command and the order in which GetGuessedParser tries


### PR DESCRIPTION
## Problem

`writeHomeBankRecords` built every line with a plain format string, without any handling of the separator:

```go
line := fmt.Sprintf("%s;%d;%s;%s;%s;%f;%s;%s",
    rec.date, rec.payment, rec.info, rec.payee, rec.memo, rec.amount, rec.category, rec.tags)
```

A semicolon inside `info`, `payee`, `memo`, `category` or `tags` therefore became an additional field separator, and a line break ended the record early. One record with such values:

```
BEFORE: 14 fields, 2 physical lines
2024-01-01;0;info;with;separator;Payee; Name;memo;with
line break;-1.500000;cat;egory;tag;one

AFTER:  8 fields, 1 physical line
2024-01-01;0;info,with,separator;Payee, Name;memo,with line break;-1.500000;cat,egory;tag,one
```

All following columns are shifted, the amount is no longer in the amount column, and the remainder of the record is read as a further record. This is not a synthetic concern: German bank data contains such values, for example a `Verwendungszweck` with a semicolon.

## Fix

Replace the separator with a comma and line breaks with a space, in the text fields only. `date` is a formatted timestamp and `payment` and `amount` are numbers, so those cannot be affected.

### Why replacing and not quoting

Quoting the affected fields was the alternative and would preserve the original characters. It was not chosen:

* The documented format does not describe a way to quote or escape a field.
* The behaviour of the importing side could not be verified while preparing this change. The network policy of the environment it was written in denies access to `homebank.free.fr` and to the distribution source browsers, so the claim "quoted separators are understood" could not be checked against the documentation or the importer implementation.

The two options fail asymmetrically. Replacing keeps the record aligned whether or not quoting would be understood. Emitting quotes that are not interpreted would keep the fields shifted and additionally put stray quote characters into the imported text, which looks fixed without being fixed.

If you can confirm that the importer follows RFC 4180 quoting, switching `writeHomeBankRecords` to `encoding/csv` with `Comma = ';'` is a small follow-up and would preserve the characters verbatim. `sanitizeHomebankField` is a single function precisely so that this stays easy to revisit.

## Tests

* `TestSanitizeHomebankField` covers a plain value, an empty value, one and several separators, all three line break variants and a value with both.
* `TestWriteHomeBankRecordsSanitizesFields` writes a record whose every text field contains a separator, plus a line break in the memo. It asserts that each written line has exactly 8 fields and compares the record against the expected line.

No expected fixture output changes, as none of the existing fixtures contains an affected character. The full suite passes unchanged, which confirms the change is additive for the existing formats.

## Verification

`make all` passes: `golangci-lint` reports 0 issues, all tests pass, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzrJKmThM4AmehDwPyxBp6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzrJKmThM4AmehDwPyxBp6)_